### PR TITLE
Enable user config for peers

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -33,9 +33,9 @@ exec -c beacon-chain \
   --verbosity $LOG_VERBOSITY \
   --p2p-tcp-port=$P2P_PORT \
   --p2p-udp-port=$P2P_PORT \
-  --p2p-max-peers=250 \
-  --min-sync-peers=0 \
-  --subscribe-all-subnets=true \
+  --p2p-max-peers="$MAX_PEERS" \
+  --min-sync-peers="$MIN_SYNC_PEERS" \
+  --subscribe-all-subnets="$SUBSCRIBE_ALL_SUBNETS" \
   --block-batch-limit=512 \
   --block-batch-limit-burst-factor=12 \
   --contract-deployment-block=0 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,9 @@ services:
       CHECKPOINT_SYNC_URL: "https://checkpoints.mainnet.lukso.network"
       EXTRA_OPTS: ""
       LOG_VERBOSITY: info
+      MIN_SYNC_PEERS: 0
+      MAX_PEERS: 250
+      SUBSCRIBE_ALL_SUBNETS: true
   validator:
     build:
       context: validator
@@ -29,6 +32,7 @@ services:
       GRAFFITI: validating_from_DAppNode
       EXTRA_OPTS: ""
       FEE_RECIPIENT_ADDRESS: ""
+      ENABLE_DOPPELGANGER: true
 volumes:
   beacon-chain-data: {}
   validator-data: {}

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -6,6 +6,10 @@ WALLET_DIR="/root/.eth2validators"
 mkdir -p ${WALLET_DIR}
 cp /auth-token ${WALLET_DIR}/auth-token
 
+if [[ $ENABLE_DOPPELGANGER == "true" ]]; then
+  EXTRA_OPTS="--enable-doppelganger ${EXTRA_OPTS}"
+fi
+
 exec -c validator \
   --datadir=/data \
   --wallet-dir="$WALLET_DIR" \
@@ -21,6 +25,5 @@ exec -c validator \
   --graffiti="$GRAFFITI" \
   --suggested-fee-recipient="${FEE_RECIPIENT_ADDRESS}" \
   --accept-terms-of-use \
-  --enable-doppelganger \
   --verbosity $LOG_VERBOSITY \
   ${EXTRA_OPTS}


### PR DESCRIPTION
Peer configuration was hradcoded, now any user can change this in the `config` tab of the Prysm LUKSO package