### PR TITLE
Set prysm version 5.0.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "prysm-lukso.dnp.dappnode.eth",
   "version": "0.1.1",
-  "upstreamVersion": "v5.0.3",
+  "upstreamVersion": "v5.0.2",
   "upstreamRepo": "prysmaticlabs/prysm",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Prysm implementation for LUKSO Beacon chain + validator",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: beacon-chain
       args:
-        UPSTREAM_VERSION: v5.0.3
+        UPSTREAM_VERSION: v5.0.2
     volumes:
       - beacon-chain-data:/data
     ports:
@@ -19,11 +19,12 @@ services:
       MIN_SYNC_PEERS: "1"
       MAX_PEERS: "250"
       SUBSCRIBE_ALL_SUBNETS: "true"
+    image: beacon-chain.prysm-lukso.dnp.dappnode.eth:0.1.1
   validator:
     build:
       context: validator
       args:
-        UPSTREAM_VERSION: v5.0.3
+        UPSTREAM_VERSION: v5.0.2
     volumes:
       - validator-data:/data
     restart: unless-stopped
@@ -31,6 +32,7 @@ services:
       LOG_VERBOSITY: info
       GRAFFITI: validating_from_DAppNode
       EXTRA_OPTS: ""
+    image: validator.prysm-lukso.dnp.dappnode.eth:0.1.1
 volumes:
   beacon-chain-data: {}
   validator-data: {}


### PR DESCRIPTION
Set prysm version `v5.0.2`

Version `v5.0.3` causes the issues described here: 
```
time="2024-05-13 10:32:45" level=info msg="Checking DB" databasePath="/data/beaconchaindata" prefix=node
time="2024-05-13 10:32:45" level=info msg="Opening Bolt DB" path="/data/beaconchaindata/beaconchain.db" prefix=db
time="2024-05-13 10:32:45" level=error msg="could not run finalized parent root index repair migration" error="unable to decode finalized block root container for root=0xfd506969f72f84838a8e807b3df0e2a5927a96b042a485a0657bed7da94def71: snappy: corrupt input" prefix=db
time="2024-05-13 10:32:45" level=fatal msg="unable to start beacon node: could not start modules: could not start DB: unable to decode finalized block root container for root=0xfd506969f72f84838a8e807b3df0e2a5927a96b042a485a0657bed7da94def71: snappy: corrupt input" prefix=main
```